### PR TITLE
Explicitly use COMMON-LISP package

### DIFF
--- a/source/package.lisp
+++ b/source/package.lisp
@@ -1,4 +1,5 @@
 (defpackage ccldoc
+  (:use :cl)
   (:import-from :alexandria
                 #:when-let* #:when-let #:if-let
                 #:starts-with-subseq)


### PR DESCRIPTION
Whether or not the CL package is used is implementation-dependent and portable code should not depend on the CL package being automatically used when the :USE clause is omitted.