### PR TITLE
Making CCLDOC A Multiimplementational System

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# lisp
+*.FASL
+*.fasl
+*.lisp-temp
+*.lx64fsl
+
+.__*
+
+# emacs
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*

--- a/source/ccldoc.asd
+++ b/source/ccldoc.asd
@@ -16,7 +16,8 @@
     :depends-on ("alexandria"
 		 "split-sequence"
 		 "s-xml"
-		 "cl-who")
+		 "cl-who"
+		 #-ccl "ccl-compat")
     :serial t
     :components ((:file "package")
 		 (:file "utils")

--- a/source/output-tracwiki.lisp
+++ b/source/output-tracwiki.lisp
@@ -105,7 +105,7 @@
       (let ((lines (split-sequence #\newline clause)))
         (loop for line in lines as first = t then nil
           do (unless first (wiki-newline stream))
-          do (let ((start (if *wiki-inline* 0 (position-if-not #'whitespacep line)))
+          do (let ((start (if *wiki-inline* 0 (position-if-not #'whitespacep line)))
                     (end (length line)))
                 (when start
                   (when-let (skip (specials line start "``" *special-at-start-of-line*))

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -1,4 +1,5 @@
 (defpackage ccldoc
+  (:use :cl)
   (:import-from :alexandria
                 #:when-let* #:when-let #:if-let
                 #:starts-with-subseq)
@@ -13,7 +14,10 @@
                 #:cheap-eval-in-environment
                 #:read-recording-source #:*loading-toplevel-location* #:*nx-source-note-map*
                 #:block-like #:progn-print #:*print-right-margin*
-                #:*show-condition-context*)
+                #:*show-condition-context*
+                #:assq #:whitespacep #:require-type #:neq #:memq
+                #:*loading-file-source-file* #:nfunction
+                #:*save-source-locations* #:record-source-file)
   ;;; Syntax.  Don't really need to export these, but might as well collect them in one place
   (:export
    ;; operators

--- a/source/representation.lisp
+++ b/source/representation.lisp
@@ -98,11 +98,8 @@
 (defmethod clause-text ((clauses list))
   (reduce (lambda (text clause) (concatenate 'string text (clause-text clause))) clauses :initial-value ""))
 
-(defclass docerror (error clause-object)
+(defclass docerror (clause-object)
   ((clause-text :initarg :message :reader clause-text)))
-
-(defmethod report-condition ((c docerror) s)
-  (write-string (clause-text c) s))
 
 ;; named clauses have a globally unique name (a lisp object, compared with EQUALP) which can be used to
 ;;  reference them from other objects.  The name is only used during compilation, once the DOM is built,
@@ -183,8 +180,17 @@
   ;; Close enough.  This is just for debugging anyway.
   (concatenate 'string (call-next-method) (string #\Newline)))
 
+#+sbcl
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (sb-ext:unlock-package (find-package :cl)))
+
+;;; TODO change this to a different name - defclassing CL:BLOCK is undefined behaviour
 (defclass block (clause-with-optional-title clause-with-body)
   ())
+
+#+sbcl
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (sb-ext:lock-package (find-package :cl)))
 
 (deftype markup-type () '(member :emphasis :system :sample :param :code))
 

--- a/source/syntax.lisp
+++ b/source/syntax.lisp
@@ -110,7 +110,9 @@
          (forms (with-ccldoc-packages
                     (with-open-file (stream *current-file*
                                             :element-type 'base-char
-                                            :external-format (if (eq external-format :default) :inferred external-format))
+                                            :external-format
+                                            #-ccl (or external-format :utf-8)
+                                            #+ccl (if (eq external-format :default) :inferred external-format))
                       (loop for form = (load-to-ccldoc-form filename stream) then (read stream nil stream)
                         until (eq form stream) collect form)))))
     (subforms-clause *parent-clause* forms)))

--- a/source/toplevel.lisp
+++ b/source/toplevel.lisp
@@ -24,7 +24,9 @@
   (with-ccldoc-packages
       (with-open-file (stream filename
                               :element-type 'base-char
-                              :external-format (if (eq external-format :default) :inferred external-format))
+                              :external-format
+                              #-ccl (or external-format :utf-8)
+                              #+ccl (if (eq external-format :default) :inferred external-format))
         (prog1 (load-to-ccldoc-form filename stream)
           (unless (eq (read stream nil :eof) :eof)
             (error "Extranenous forms following document in ~s" filename))))))


### PR DESCRIPTION
This is a series of patches to make CCLDOC run on other implementations with use of my [CCL-COMPAT](https://github.com/phoe/ccl-compat) module. Tested this on SBCL/Linux and ECL/Linux so far.

#7 was my previous, very messy attempt - I'm sorry for submitting it, it was way too early.