### PR TITLE
Fixed compatibility with LispWorks

### DIFF
--- a/ccldoc.ccldoc
+++ b/ccldoc.ccldoc
@@ -40,7 +40,8 @@
 
 ;; Use this package to show explicit packages on unexported symbols...
 (defpackage :ccldoc-documentation
-  (:use :ccldoc :cl))
+  (:use :ccldoc :cl)
+  #-:ccl (:shadow :block))
 
 
 

--- a/source/output-html.lisp
+++ b/source/output-html.lisp
@@ -1,6 +1,6 @@
 (in-package :ccldoc)
 
-(defun output-html (doc filename &key external-format (if-exists :supersede)
+(defun output-html (doc filename &key (external-format :default) (if-exists :supersede)
 				   stylesheet)
   (with-open-file (s filename :direction :output :if-exists if-exists
 		     :external-format external-format)

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -4,7 +4,8 @@
                 #:when-let* #:when-let #:if-let
                 #:starts-with-subseq)
   (:import-from :split-sequence #:split-sequence)
-  (:import-from :ccl
+  (:import-from #+:ccl :ccl
+                #-:ccl :ccl-compat
                 #:pkg-arg #:no-such-package
                 #:report-condition
                 #:definition-base-name #:definition-type-instance #:method-def-parameters
@@ -18,6 +19,7 @@
                 #:assq #:whitespacep #:require-type #:neq #:memq
                 #:*loading-file-source-file* #:nfunction
                 #:*save-source-locations* #:record-source-file)
+  #-:ccl (:shadow :block)
   ;;; Syntax.  Don't really need to export these, but might as well collect them in one place
   (:export
    ;; operators

--- a/source/representation.lisp
+++ b/source/representation.lisp
@@ -55,7 +55,9 @@
   (let ((text (clause-text c)))
     (when (> (length text) 50)
       (setq text (concatenate 'string (subseq text 0 50) "...")))
-    (setq text (substitute #\nko_digit_one #\newline text))
+    (setq text (substitute #-:lispworks #\nko_digit_one
+                           #+:lispworks #\U+07c1
+                           #\newline text))
     (princ text stream)))
 
 ;; Could automate this, but for now.


### PR DESCRIPTION
Tested with LispWorks 6.1 Personal and 7.0 for Windows, CCL 1.11-r16635  (WindowsX8664), sbcl 1.3.15 Windows
Requires updates in ccl-compat for these (except CCL of course) compilers.
Corresponding pull-request in ccl-compat is already merged.